### PR TITLE
API changes to `create_synapse()` and ability to see delay chain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "superneuromat"
-version = "3.0.1"
+version = "3.1.0"
 requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.24.0",

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -432,6 +432,32 @@ class Synapse:
     def weight(self, value: float):
         self.m.synaptic_weights[self.idx] = float(value)
 
+    @property
+    def delay_chain(self):
+        """Returns a list of neurons in the delay chain for this synapse.
+
+        The list is in the same order that spikes will pass through the chain.
+
+        Returns ``[]`` if synapse is not the last synapse in a delay chain."""
+        if self.delay > 0:
+            return []
+        second = self.pre.idx + self.delay + 2
+        last = self.pre.idx + 1
+        first_syn = self.m.synapses[self.idx + self.delay + 1]
+        return [first_syn.pre] + self.m.neurons[second:last] + [self.post]
+
+    @property
+    def delay_chain_synapses(self):
+        """A list of synapses in the delay chain for this synapse.
+
+        The list is in the same order that spikes will pass through the chain.
+
+        Returns ``[]`` if synapse is not the last synapse in a delay chain."""
+        if self.delay > 0:
+            return []
+        first_syn = self.m.synapses[self.idx + self.delay + 1]
+        return self.m.synapses[first_syn.idx:self.idx] + [self]
+
     def __eq__(self, x):
         """Check if two Synapse instances represent the same synapse in the SNN."""
         if isinstance(x, Synapse):
@@ -440,7 +466,11 @@ class Synapse:
             return False
 
     def info(self):
-        """Returns a string containing information about this synapse."""
+        """Returns a string containing information about this synapse.
+
+        Note that a dash ``-`` is used to represent that the synapse
+        is the last in a delay chain. See :py:meth:`create_synapse`\\ .
+        """
         return ' | '.join([
             f"id: {self.idx:d}",
             f"pre: {self.pre_id:d}",
@@ -454,24 +484,28 @@ class Synapse:
         return f"<Synapse {self.info()}>"
 
     def info_row(self):
-        """Returns a string containing information about this synapse for use in a table."""
+        """Returns a string containing information about this synapse for use in a table.
+
+        Note that a dash ``-`` is used to represent that the synapse
+        is the last in a delay chain. See :py:meth:`create_synapse`\\ .
+        """
         delaystr = f"{'- ' if self.delay < 1 else '  '}{abs(self.delay):d}"
         return ''.join([
-            f"{self.idx:>5d}\t",
-            f"{self.pre_id:>5d}  ",
-            f"{self.post_id:>5d}\t",
-            f"{self.weight:>11.9g}\t",
-            f"{delaystr:>6}\t",
+            f"{self.idx:>7d} ",
+            f"{self.pre_id:>6d} -> ",
+            f"{self.post_id:>6d} ",
+            f"{self.weight:>11.7g} ",
+            f"{delaystr:>7} ",
             f"{'Y' if self.stdp_enabled else '-'}",
         ])
 
     @staticmethod
     def row_header():
-        return "  idx\t  pre   post\t     weight\t  delay\tstdp_enabled"
+        return "    idx    pre ->   post      weight    delay stdp_enabled"
 
     @staticmethod
     def row_cont():
-        return "  ...\t  ...    ...\t        ...\t    ...\t..."
+        return "    ...    ...       ...         ...      ... ..."
 
 
 class SynapseList:

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -409,6 +409,8 @@ class Synapse:
 
     @delay.setter
     def delay(self, value):
+        if value != self.m.synaptic_delays[self.idx]:
+            raise ValueError("delay cannot be changed on chained synapse.")
         if not is_intlike(value):
             raise TypeError("delay must be an integer")
         self.m.synaptic_delays[self.idx] = int(value)
@@ -444,7 +446,7 @@ class Synapse:
             f"pre: {self.pre_id:d}",
             f"post: {self.post_id:d}",
             f"weight: {self.weight:g}",
-            f"delay: {self.delay:d}",
+            f"delay: {'- ' if self.delay < 1 else '  '}{abs(self.delay):d}",
             f"stdp {'en' if self.stdp_enabled else 'dis'}abled",
         ])
 
@@ -453,22 +455,23 @@ class Synapse:
 
     def info_row(self):
         """Returns a string containing information about this synapse for use in a table."""
+        delaystr = f"{'- ' if self.delay < 1 else '  '}{abs(self.delay):d}"
         return ''.join([
             f"{self.idx:>5d}\t",
             f"{self.pre_id:>5d}  ",
             f"{self.post_id:>5d}\t",
             f"{self.weight:>11.9g}\t",
-            f"{self.delay:>5d}\t",
+            f"{delaystr:>6}\t",
             f"{'Y' if self.stdp_enabled else '-'}",
         ])
 
     @staticmethod
     def row_header():
-        return "  idx\t  pre   post\t     weight\tdelay\tstdp_enabled"
+        return "  idx\t  pre   post\t     weight\t  delay\tstdp_enabled"
 
     @staticmethod
     def row_cont():
-        return "  ...\t  ...    ...\t        ...\t  ...\t..."
+        return "  ...\t  ...    ...\t        ...\t    ...\t..."
 
 
 class SynapseList:

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -943,12 +943,24 @@ class SNN:
         weight : float, default=1.0
             Synaptic weight; weight is multiplied to the incoming spike.
         delay : int, default=1
-            Synaptic delay; number of time steps by which the outgoing signal of the syanpse is delayed by.
+            Synaptic delay; number of time steps by which the outgoing signal of the synapse is delayed by.
         stdp_enabled : bool | Any, default=False
             If True, stdp will be enabled on the synapse, allowing the weight of this synapse to be updated.
         exist : str, default='error'
-            Action if a queued spike already exists at the given time step.
+            Action if synapse  already exists with the exact pre- and post-synaptic neurons.
             Should be one of ['error', 'overwrite', 'dontadd'].
+
+
+        If a delay is specified, a chain of neurons and synapses will automatically be added to the model
+        to represent the delay, and this function will return the last synapse of the chain.
+        The other neurons and synapses in the chain can be accessed via the :py:attr:`delay_chain` and
+        :py:attr:`delay_chain_synapses` properties of the synapse, respectively.
+
+        While only positive delay values are supported due to temporal consistency and causality requirements,
+        The delay will be stored as ``delay * -1`` in the model to represent that it is a chained delay.
+        This does not affect the effective delay value, as the delay will still be applied via the delay chain.
+
+        Note that delays of delay chains cannot be modified after creation.
 
         Raises
         ------
@@ -979,6 +991,10 @@ class SNN:
 
            :py:meth:`Neuron.connect_child`, :py:meth:`Neuron.connect_parent`
         """
+
+        # TODO: raise error on unknown kwargs
+        # TODO: make delay chaining an SNN option
+        # TODO: ensure created hidden synapses are not flagged as newdelay
 
         # Ensure we work with neuron ids
         if isinstance(pre_id, Neuron):

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -1052,7 +1052,7 @@ class SNN:
             exist = exist.lower()
             if exist == "error":
                 msg = f"Synapse already exists: {self.synapses[idx]!s}"
-                msg += "If this was intentional, pass arg exist='add', 'dontadd', 'overwrite'."
+                msg += "If this was intentional, choose arg exist=<'dontadd', 'overwrite'>."
                 raise RuntimeError(msg)
             elif exist == "overwrite":
                 # check if delay has changed

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -1045,8 +1045,6 @@ class SNN:
                 raise ValueError(msg)
             return self.synapses[idx]  # prevent fall-through if user catches the error
 
-        idx = self.num_synapses  # this will become the new id of the synapse
-
         # Set new synapse parameters
         if delay == 1:
             self.pre_synaptic_neuron_ids.append(pre_id)
@@ -1054,7 +1052,7 @@ class SNN:
             self.synaptic_weights.append(weight)
             self.synaptic_delays.append(delay)
             self.enable_stdp.append(stdp_enabled)
-            self.connection_ids[(pre_id, post_id)] = idx
+            self.connection_ids[(pre_id, post_id)] = self.num_synapses - 1
         else:
             for _d in range(int(delay) - 1):  # delay by stringing together hidden synapses
                 temp_id = self.create_neuron()
@@ -1064,7 +1062,7 @@ class SNN:
             self.create_synapse(pre_id, post_id, weight=weight, stdp_enabled=stdp_enabled)
 
         # Return synapse ID
-        return Synapse(self, idx)
+        return Synapse(self, self.num_synapses - 1)
 
     def add_spike(
         self,

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -992,7 +992,6 @@ class SNN:
            :py:meth:`Neuron.connect_child`, :py:meth:`Neuron.connect_parent`
         """
 
-        # TODO: raise error on unknown kwargs
         # TODO: make delay chaining an SNN option
         # TODO: ensure created hidden synapses are not flagged as newdelay
 
@@ -1042,6 +1041,10 @@ class SNN:
         last_in_chain = kwargs.pop('_is_last_chained_synapse', False)
         if delay <= 0 and not last_in_chain:
             raise ValueError("delay must be greater than or equal to 1")
+
+        if kwargs:
+            msg = f"create_synapse() received unexpected keyword arguments: {list(kwargs.keys())}"
+            raise TypeError(msg)
 
         if (idx := self.get_synapse_id(pre_id, post_id)) is not None:  # if synapse already exists
             if not isinstance(exist, str):

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -1012,13 +1012,19 @@ class SNN:
             msg = f"Added synapse to non-existent post-synaptic Neuron {post_id}."
             raise warnings.warn(msg, stacklevel=2)
 
+        if (enable_stdp := kwargs.pop('enable_stdp', None)) is not None:
+            warnings.warn("create_synapse kwarg 'enable_stdp' is deprecated. Use 'stdp_enabled' instead.",
+                          DeprecationWarning, stacklevel=2)
+            stdp_enabled = enable_stdp
+
         ambiguous = ('true', '1', 'y', 'yes', 'on', 'f', 'false', '0', 'n', 'no', 'off')
         if isinstance(stdp_enabled, str) and stdp_enabled.lower() in ambiguous:
             msg = f"{fname} argument stdp_enabled received {stdp_enabled!r}"
             msg += " which has ambiguous truthiness. Consider using an explicit boolean value instead."
             warnings.warn(msg, stacklevel=2)
 
-        if delay <= 0:
+        last_in_chain = kwargs.pop('_is_last_chained_synapse', False)
+        if delay <= 0 and not last_in_chain:
             raise ValueError("delay must be greater than or equal to 1")
 
         if (idx := self.get_synapse_id(pre_id, post_id)) is not None:  # if synapse already exists

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -159,7 +159,7 @@ class SynapseTest(unittest.TestCase):
             syn.delay = 1
 
     def test_synapse_get_delay_chain(self):
-        """ Test if error raised when changing delay on chained synapse
+        """ Test if synapse delay chain properties work as expected
 
         """
         # Create SNN, neurons, and synapses
@@ -174,6 +174,9 @@ class SynapseTest(unittest.TestCase):
         print(snn)
         print(neuron_chain)
         print(*(syn.info_row() for syn in synapse_chain), sep='\n')
+        assert [int(n.idx) for n in neuron_chain] == [0, 2, 3, 1]
+        assert [int(s.idx) for s in synapse_chain] == [0, 1, 2]
+        assert snn.synapses[0].delay_chain == []
 
 
 

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -141,6 +141,41 @@ class SynapseTest(unittest.TestCase):
 
         print("test_get_synapses completed successfully")
 
+    def test_synapse_change_chained_delay(self):
+        """ Test if error raised when changing delay on chained synapse
+
+        """
+        # Create SNN, neurons, and synapses
+        snn = SNN()
+
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        syn = snn.create_synapse(a, b, delay=2, stdp_enabled=True)  # a -> _ -> b  (hidden neuron created)
+        snn.create_synapse(a, b, delay=1, stdp_enabled=True)  # this is fine because a -> b doesn't exist yet
+        with self.assertRaises(ValueError):
+            snn.create_synapse(syn.pre, syn.post, delay=1, stdp_enabled=True, exist='overwrite')
+        with self.assertRaises(ValueError):
+            syn.delay = 1
+
+    def test_synapse_get_delay_chain(self):
+        """ Test if error raised when changing delay on chained synapse
+
+        """
+        # Create SNN, neurons, and synapses
+        snn = SNN()
+
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        syn = snn.create_synapse(a, b, delay=3, stdp_enabled=True)  # a -> _ -> b  (hidden neuron created)
+        neuron_chain = syn.delay_chain
+        synapse_chain = syn.delay_chain_synapses
+        print(snn)
+        print(neuron_chain)
+        print(*(syn.info_row() for syn in synapse_chain), sep='\n')
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #1, #2, #3 and adds accessors to see neurons and synapses that are part of a delay chain (as long as you have the last synapse in that chain).

Also, version bump to 3.1.0